### PR TITLE
thread_sleep 수정

### DIFF
--- a/threads/thread.c
+++ b/threads/thread.c
@@ -614,20 +614,17 @@ void thread_sleep(int64_t ticks){
  - 함수가 다 실행되면 인터럽트를 받아들인다.
  */
 
+	enum intr_level old_level =intr_disable (); // Disables interrupts and returns the previous interrupt status.
  	struct thread *curr = thread_current ();  //   얘를 블락시키기 -> 깨어나야할 시간(tick)을 저장
-	enum intr_level old_level;
-	intr_disable ();   // Disables interrupts and returns the previous interrupt status.
-
+   
 	if (curr != idle_thread)
 	{
-		thread_block();
-		curr->elem = sleep_list.head;
-		sleep_list.head.next = curr->elem.next;
-
-		do_schedule (THREAD_BLOCKED);
+		list_push_back(&sleep_list, &curr->elem);
 		curr->wakeup_tick = ticks;
+		update_next_tick_to_awake(ticks);    
+		thread_block();
 	}
-	intr_enable();
+  	intr_set_level(old_level);                 // 기존 인터럽트 레벨을 복구(원래 disabled였을 수도 있어서)
 }
 
 /*TBD sunny: wakeup_tick값이 ticks보다 작거나 같은 쓰레드를 깨움


### PR DESCRIPTION
- list_push_back 방식으로 sleep list의 가장 뒤에 스레드를 넣어줌
- update_next_tick_to_awake 를 통해 만약 현재 ticks가 기존 next_tick_to_awake 보다 작다면 next_tick_to_awake 를 tics로 업데이되도록 해줌
- thread_block 은 함수 가장 마지막에 하도록 함. ( THREAD_BLOCKED status도 이 함수 안에서 변경됨 )
- 원래 disabled였을 수도 있으므로, intr_enable 대신 intr_set_level(old_level); 로 변경     
