### PR TITLE
SYS_CLOSE 구현

### DIFF
--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -106,9 +106,9 @@ syscall_handler (struct intr_frame *f UNUSED) {
 		// case SYS_TELL:
 		// 	tell();
 		// 	break;
-		// case SYS_CLOSE:
-		// 	close();
-		// 	break;
+		case SYS_CLOSE:
+			close(f->R.rdi);
+			break;
 		default:
 			// thread_exit()
 			break;
@@ -231,7 +231,13 @@ int write (int fd, const void *buffer, unsigned size) {
 // 	return file_tell(fd);
 // }
 
-// // close() -> fd가 가르키는 파일 닫기
-// void close (int fd) {
-// 	return file_close(fd);
-// }
+// close() -> fd가 가르키는 파일 닫고, 해당 fd를 fd_arr에서 할당해제
+void close (int fd) {
+	struct file* file_obj;
+	file_obj = thread_current()->fd_arr[fd];
+	if (file_obj == NULL) {
+		exit(-1);
+	}
+	file_close(file_obj);
+	thread_current()->fd_arr[fd] = NULL;
+}


### PR DESCRIPTION
- SYS_CLOSE 구현
  - 기존에 이 분기가 활성화되어있지 않았는데 close 테스트들이 통과하고 있던 이유는 알 수 없음 
  - fd_arr 에서 해당하는 파일을 찾아 close후 할당해제하도록 함

- 테스트 결과 이상없음
![image](https://user-images.githubusercontent.com/50320497/203900208-1c91c0c5-a2c7-4bc3-924c-8965b1a4c5c0.png)
